### PR TITLE
Remove Deprecated configuration 'strict'.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,6 @@
          convertWarningsToExceptions="true"
          convertErrorsToExceptions="true"
          mapTestClassNameToCoveredClassName="false"
-         strict="true"
          verbose="true"
          bootstrap="./Suitmedia/Tests/bootstrap.php">
 


### PR DESCRIPTION
`strict` configuration is already deprecated since 4.5 and it causes our test skiped, please see [ before](https://travis-ci.org/suitmedia/php-code-standards/jobs/116046872#L211-L223) and [after](https://travis-ci.org/feryardiant/suitmedia-code-standards/jobs/116301776#L216)
