### PR TITLE
Don't begin function name with capital letter

### DIFF
--- a/Suitmedia/ruleset.xml
+++ b/Suitmedia/ruleset.xml
@@ -47,6 +47,7 @@
     <rule ref="PEAR.NamingConventions.ValidFunctionName">
         <exclude name="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore"/>
         <exclude name="PEAR.NamingConventions.ValidFunctionName.FunctionUnderscore"/>
+        <exclude name="PEAR.NamingConventions.ValidFunctionName.FunctionNoCapital" />
     </rule>
 
     <rule ref="vendor/cakephp/cakephp-codesniffer/CakePHP/Sniffs/Formatting/OneClassPerUseSniff.php"/>


### PR DESCRIPTION
Because `PEAR.NamingConventions.ValidFunctionName`  require function name that prefixed with package name must begin with capital letter, so it cause an error.

```
Function name "some_func" is prefixed with a package name but does not begin with a capital letter
```

This issue only appears to function with `underscore`, so PEAR NamingConventions assumed that the first word is a package name.

Info : https://stackoverflow.com/a/20603016/881743